### PR TITLE
Fix Jenkins-X updatebot Maven plugin groupId

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/kind/maven/MavenUpdater.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/kind/maven/MavenUpdater.java
@@ -72,7 +72,7 @@ public class MavenUpdater extends UpdaterSupport implements Updater {
             String updateBotPluginVersion = VersionHelper.updateBotVersion();
             if (ProcessHelper.runCommandAndLogOutput(context.getConfiguration(), LOG, context.getDir(), env, mvnCommand,
                     "-B",
-                    "io.fabric8.updatebot:updatebot-maven-plugin:" + updateBotPluginVersion + ":export",
+                    "io.jenkins.updatebot:updatebot-maven-plugin:" + updateBotPluginVersion + ":export",
                     "-DdestFile=" + versionsFile, "-DupdateBotYaml=" + configFile)) {
                 if (!Files.isFile(versionsFile)) {
                     LOG.warn("Should have generated the export versions file " + versionsFile);


### PR DESCRIPTION
Fixes #34 when running below command from Maven build pod inside Jenkins-X CI/CD pipeline

```
mvn -B io.jenkins.updatebot:updatebot-maven-plugin:1.1.13:export -DdestFile=./target/updatebot-versions.yaml -DupdateBotYaml=.updatebot.yml
```
