### PR TITLE
Custom remote branch name for downstream repositories

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/CommandNames.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/CommandNames.java
@@ -18,6 +18,7 @@ package io.jenkins.updatebot;
 /**
  */
 public final class CommandNames {
+    public static final String VERSION = "version";
     public static final String HELP = "help";
     public static final String PULL = "pull";
     public static final String PUSH_VERSION = "push-version";

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/UpdateBot.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/UpdateBot.java
@@ -15,7 +15,28 @@
  */
 package io.jenkins.updatebot;
 
+import static io.jenkins.updatebot.CommandNames.HELP;
+import static io.jenkins.updatebot.CommandNames.PULL;
+import static io.jenkins.updatebot.CommandNames.PUSH_REGEX;
+import static io.jenkins.updatebot.CommandNames.PUSH_SOURCE;
+import static io.jenkins.updatebot.CommandNames.PUSH_VERSION;
+import static io.jenkins.updatebot.CommandNames.UPDATE;
+import static io.jenkins.updatebot.CommandNames.UPDATE_LOOP;
+import static io.jenkins.updatebot.CommandNames.VERSION;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.beust.jcommander.JCommander;
+
 import io.jenkins.updatebot.commands.CommandContext;
 import io.jenkins.updatebot.commands.CommandSupport;
 import io.jenkins.updatebot.commands.Help;
@@ -27,24 +48,7 @@ import io.jenkins.updatebot.commands.PushVersionChanges;
 import io.jenkins.updatebot.commands.StatusInfo;
 import io.jenkins.updatebot.commands.UpdatePullRequestLoop;
 import io.jenkins.updatebot.commands.UpdatePullRequests;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import static io.jenkins.updatebot.CommandNames.HELP;
-import static io.jenkins.updatebot.CommandNames.PULL;
-import static io.jenkins.updatebot.CommandNames.PUSH_REGEX;
-import static io.jenkins.updatebot.CommandNames.PUSH_SOURCE;
-import static io.jenkins.updatebot.CommandNames.PUSH_VERSION;
-import static io.jenkins.updatebot.CommandNames.UPDATE;
-import static io.jenkins.updatebot.CommandNames.UPDATE_LOOP;
+import io.jenkins.updatebot.commands.Version;
 
 /**
  */
@@ -81,10 +85,12 @@ public class UpdateBot {
         UpdatePullRequests updatePullRequests = new UpdatePullRequests();
         UpdatePullRequestLoop updatePullRequestLoop = new UpdatePullRequestLoop();
         Help help = new Help();
+        Version version = new Version();
 
         JCommander commander = JCommander.newBuilder()
                 .addObject(config)
                 .addCommand(HELP, help)
+                .addCommand(VERSION, version)
                 .addCommand(PULL, pullVersionChanges)
                 .addCommand(PUSH_REGEX, pushRegexChanges)
                 .addCommand(PUSH_SOURCE, pushSourceChanges)
@@ -103,6 +109,9 @@ public class UpdateBot {
             switch (parsedCommand) {
                 case HELP:
                     return help;
+
+                case VERSION:
+                    return version;
 
                 case PULL:
                     return pullVersionChanges;

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
@@ -67,7 +67,7 @@ public class PushSourceChangesContext extends CommandContext {
 
     @Override
     public String createPullRequestTitlePrefix() {
-        return "push " + command.getRepositoryFullName() + " ";
+        return "update " + command.getRepositoryFullName() + " to ";
     }
 
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
@@ -56,7 +56,7 @@ public class PushSourceChangesContext extends CommandContext {
     public String createCommit() {
         String gitUrl = command.getRepositoryFullName();
         String ref = command.getRef();
-        return "fix(versions): " + gitUrl + "\n\n" +
+        return "fix(versions): push " + gitUrl + " ref: " + ref + "\n\n" +
                 "Push version changes from the source code in repository: " + gitUrl + " ref: " + ref + "\n";
     }
 

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/Version.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/Version.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.jenkins.updatebot.commands;
+
+import java.io.IOException;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import io.jenkins.updatebot.CommandNames;
+import io.jenkins.updatebot.Configuration;
+import io.jenkins.updatebot.support.VersionHelper;
+
+/**
+ * Displays version
+ */
+@Parameters(commandNames = CommandNames.VERSION, commandDescription = "Displays updatebot version")
+public class Version extends CommandSupport {
+    @Parameter()
+    private String command;
+
+    private JCommander commander;
+
+
+    @Override
+    public ParentContext run(Configuration configuration) throws IOException {
+        showVersion();
+        return new ParentContext();
+    }
+
+    @Override
+    public void run(CommandContext context) throws IOException {
+        showVersion();
+    }
+
+    public void showVersion() {
+        System.out.println(VersionHelper.updateBotVersion());
+    }
+
+    public JCommander getCommander() {
+        return commander;
+    }
+
+    public void setCommander(JCommander commander) {
+        this.commander = commander;
+    }
+}

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPlugin.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPlugin.java
@@ -57,5 +57,7 @@ public interface GitPlugin {
 
     boolean stashAndCheckoutMaster(File dir);
 
+    boolean stashAndCheckoutBranch(File dir, String branch);
+
     void revertChanges(File dir) throws IOException;
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
@@ -118,8 +118,13 @@ public class GitPluginCLI implements GitPlugin {
 
     @Override
     public boolean stashAndCheckoutMaster(File dir) {
+        return stashAndCheckoutBranch(dir, "master");
+    }
+
+    @Override
+    public boolean stashAndCheckoutBranch(File dir, String branch) {
         if (ProcessHelper.runCommandIgnoreOutput(dir, "git", "stash") == 0) {
-            if (ProcessHelper.runCommandIgnoreOutput(dir, "git", "checkout", "master") == 0) {
+            if (ProcessHelper.runCommandIgnoreOutput(dir, "git", "checkout", branch) == 0) {
                 return true;
             }
         }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
@@ -22,6 +22,7 @@ import io.jenkins.updatebot.support.Strings;
  */
 public class GitRepositoryConfig extends DtoSupport {
     private String name;
+    private String branch; // need to resolve branch name at runtime
     private Dependencies push;
     private Dependencies pull;
 
@@ -37,9 +38,10 @@ public class GitRepositoryConfig extends DtoSupport {
         String nameText = Strings.notEmpty(name) ? "name='" + name + '\'' : "";
         String pushText = push != null ? "push=" + push : "";
         String pullText = pull != null ? "pull=" + pull : "";
+        String branchText = pull != null ? "branch=" + branch : "";
 
         return "GitRepositoryConfig{" +
-                Strings.joinNotEmpty(", ", nameText, pushText, pullText) + '}';
+                Strings.joinNotEmpty(", ", nameText, pushText, pullText, branchText) + '}';
     }
 
     public String getName() {
@@ -64,6 +66,14 @@ public class GitRepositoryConfig extends DtoSupport {
 
     public void setPull(Dependencies pull) {
         this.pull = pull;
+    }
+
+    public String getBranch() {
+        return this.branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
     }
 
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/repository/LocalRepository.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/repository/LocalRepository.java
@@ -15,20 +15,24 @@
  */
 package io.jenkins.updatebot.repository;
 
+import static io.jenkins.updatebot.Configuration.DEFAULT_CONFIG_FILE;
+
+import io.fabric8.utils.Files;
+import io.fabric8.utils.Objects;
 import io.jenkins.updatebot.Configuration;
+import io.jenkins.updatebot.github.GitHubHelpers;
 import io.jenkins.updatebot.model.GitRepository;
 import io.jenkins.updatebot.model.GitRepositoryConfig;
+import io.jenkins.updatebot.model.GithubRepository;
 import io.jenkins.updatebot.model.RepositoryConfig;
 import io.jenkins.updatebot.model.RepositoryConfigs;
 import io.jenkins.updatebot.support.Strings;
-import io.fabric8.utils.Files;
-import io.fabric8.utils.Objects;
+
+import org.kohsuke.github.GHRepository;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-
-import static io.jenkins.updatebot.Configuration.DEFAULT_CONFIG_FILE;
 
 /**
  */
@@ -94,6 +98,24 @@ public class LocalRepository {
     }
 
     /**
+     * Returns the local repository for the given GHRepository with matching transport url
+     */
+    public static LocalRepository findRepository(List<LocalRepository> localRepositories, GHRepository ghRepository) {
+        if (localRepositories != null) {
+            for (LocalRepository repository : localRepositories) {
+                GitRepository repo = repository.getRepo();
+                if (repo != null) {
+                    if (Objects.equal(repo.getCloneUrl(), ghRepository.getGitTransportUrl())) {
+                        return repository;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+
+    /**
      * Returns the link to the repository
      */
     public static String getRepositoryLink(LocalRepository repository) {
@@ -153,5 +175,42 @@ public class LocalRepository {
     public boolean hasCloneUrl(String cloneUrl) {
         // sometimes folks miss off the ".git" from URLs so lets check for that too
         return repo.hasCloneUrl(cloneUrl) || repo.hasCloneUrl(cloneUrl + ".git");
+    }
+
+    /**
+     * Resolves remote branch name at runtime using a combination of .updatebot.yml setting, or Github default branch,
+     * or master as fallback. If branch is not set, tries to resolve default branch name from remote Github repository
+     * in order to create PRs with updates using the same branch.
+     *
+     * Returns remote branch name to use
+     *
+     */
+    public String resolveRemoteBranch() {
+        // Let's try use repository branch from .updatebot.yml first
+        GitRepositoryConfig config = repo.getRepositoryDetails();
+
+        if(!Strings.empty(config.getBranch())) {
+            return config.getBranch();
+        } // Try detect Github repository and use its default branch
+        else if(repo instanceof GithubRepository) {
+            GHRepository ghRepository = GitHubHelpers.getGitHubRepository(this);
+            if (ghRepository != null) {
+                config.setBranch(ghRepository.getDefaultBranch());
+            }
+        } else {
+            config.setBranch("master");
+        }
+
+        return config.getBranch();
+    }
+
+
+    /**
+     * Returns configured remote branch from repository configuration details
+     */
+    public String getRemoteBranch() {
+        GitRepositoryConfig config = repo.getRepositoryDetails();
+
+        return config.getBranch();
     }
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/repository/Repositories.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/repository/Repositories.java
@@ -15,6 +15,7 @@
  */
 package io.jenkins.updatebot.repository;
 
+import io.fabric8.utils.Filter;
 import io.jenkins.updatebot.Configuration;
 import io.jenkins.updatebot.github.GitHubHelpers;
 import io.jenkins.updatebot.model.GitHubProjects;
@@ -25,7 +26,7 @@ import io.jenkins.updatebot.model.GithubRepository;
 import io.jenkins.updatebot.model.RepositoryConfig;
 import io.jenkins.updatebot.support.FileHelper;
 import io.jenkins.updatebot.support.Strings;
-import io.fabric8.utils.Filter;
+
 import org.kohsuke.github.GHPerson;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -59,9 +60,15 @@ public class Repositories {
         File dir = repository.getDir();
         String secureCloneUrl = repository.getRepo().secureCloneUrl(configuration);
         File gitDir = new File(dir, ".git");
+
         if (gitDir.exists()) {
-            if (configuration.getGit().stashAndCheckoutMaster(dir)) {
+            // Let's resolve clone branch from local repository
+            String branch = repository.resolveRemoteBranch();
+
+            configuration.info(LOG, "Checkout branch: " + branch + " from " + repository.getFullName() + " in " + FileHelper.getRelativePathToCurrentDir(dir));
+            if (configuration.getGit().stashAndCheckoutBranch(dir, branch)) {
                 if (!configuration.isPullDisabled()) {
+                    configuration.info(LOG, "Pull branch: " + branch + " from " + repository.getFullName() + " in " + FileHelper.getRelativePathToCurrentDir(dir));
                     configuration.getGit().pull(dir, repository.getCloneUrl());
                 }
             }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/support/FileMatcher.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/support/FileMatcher.java
@@ -15,13 +15,14 @@
  */
 package io.jenkins.updatebot.support;
 
-import io.fabric8.utils.Files;
-import org.springframework.util.AntPathMatcher;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.springframework.util.AntPathMatcher;
+
+import io.fabric8.utils.Files;
 
 /**
  */
@@ -55,7 +56,7 @@ public class FileMatcher {
             }
         } else {
             String path = Files.getRelativePath(rootDir, file);
-            path = Strings.trimAllPrefix(path, "/");
+            path = Strings.trimAllPrefix(path, File.separator);
             if (matchesPatterns(path, includes) && !matchesPatterns(path, excludes)) {
                 answer.add(file);
             }

--- a/updatebot-core/src/test/java/io/jenkins/updatebot/RepositoryConfigTest.java
+++ b/updatebot-core/src/test/java/io/jenkins/updatebot/RepositoryConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package io.jenkins.updatebot;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.fabric8.updatebot.test.Tests;
+import io.jenkins.updatebot.commands.PushSourceChanges;
+import io.jenkins.updatebot.model.RepositoryConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ */
+public class RepositoryConfigTest {
+    private static final transient Logger LOG = LoggerFactory.getLogger(RepositoryConfigTest.class);
+
+    protected PushSourceChanges pushSourceChanges = new PushSourceChanges();
+    protected Configuration testSubject;
+
+    @Before
+    public void init() throws IOException {
+        this.testSubject = new Configuration();
+
+        String workDirPath = Tests.getCleanWorkDir(getClass());
+        testSubject.setWorkDir(workDirPath);
+    }
+
+    @Test
+    public void testBranchConfiguration() throws Exception {
+        // given
+        String configFile = new File(Tests.getBasedir(), "src/test/resources/maven/branch/updatebot-develop.yml").getPath();
+        testSubject.setConfigFile(configFile);
+
+        // when
+        RepositoryConfig repositoryConfig = pushSourceChanges.getRepositoryConfig(testSubject);
+
+        // then
+        assertThat(repositoryConfig.getGithub().findOrganisation("jstrachan-testing").findRepository("updatebot").getBranch()).isEqualTo("develop");
+    }
+
+    @Test
+    public void testNoBranchConfigurationDefaultsToNull() throws Exception {
+        // given
+        String configFile = new File(Tests.getBasedir(), "src/test/resources/maven/branch/updatebot-master.yml").getPath();
+        testSubject.setConfigFile(configFile);
+
+        // when
+        RepositoryConfig repositoryConfig = pushSourceChanges.getRepositoryConfig(testSubject);
+
+        // then
+        assertThat(repositoryConfig.getGithub().findOrganisation("jstrachan-testing").findRepository("updatebot").getBranch()).isNull();
+    }
+
+}

--- a/updatebot-core/src/test/resources/maven/branch/updatebot-develop.yml
+++ b/updatebot-core/src/test/resources/maven/branch/updatebot-develop.yml
@@ -1,0 +1,13 @@
+github:
+  organisations:
+  - name: jstrachan-testing
+    repositories:
+    - name: updatebot
+      branch: develop
+      push:
+        maven:
+          dependencies:
+          - groupInclude: org.apache*
+          - groupInclude: org.springframework
+          - artifactInclude: foo-bar
+

--- a/updatebot-core/src/test/resources/maven/branch/updatebot-master.yml
+++ b/updatebot-core/src/test/resources/maven/branch/updatebot-master.yml
@@ -1,0 +1,12 @@
+github:
+  organisations:
+  - name: jstrachan-testing
+    repositories:
+    - name: updatebot
+      push:
+        maven:
+          dependencies:
+          - groupInclude: org.apache*
+          - groupInclude: org.springframework
+          - artifactInclude: foo-bar
+


### PR DESCRIPTION
This PR fixes #38 by providing new option to configure and use custom remote branch name for downstream repositories declared in .updatebot.yml file. 

When run updatebot push --ref tag into downstream repository, the remote branch name is resolved at run-time using a chain of .updatebot.yml settings, or Github default branch, 

so that, If branch is not set in .updatebot.yml, it tries to resolve default branch name from remote Github repository. Otherwise, it will use 'master' as fallback for Git repositories, and so that,

downstream repositories are cloned and checked out using remote branch name, and so that,

pull requests are created to merge into the same remote branch.

It also fixes a few glitches and minor features, such as 

* fix: use platform dependent File.separator to match files
* feat: new CLI command: updatebot version
* fix: polish PR title prefix text for push command
* fix: set default local name to Git repository full name using clone url
* fix: polish push command commit text to include ref value

@jstrachan You can see the running examples between https://github.com/igdianov/upstream and https://github.com/igdianov/downstream repositories using builder-maven with these fixes. Let me know if you find any problem with the changes. Thanks!