### PR TITLE
allow user to choose whether to check PR status before merging

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/EnvironmentVariables.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/EnvironmentVariables.java
@@ -29,6 +29,9 @@ public class EnvironmentVariables {
     public static final String POLL_PERIOD = "UPDATEBOT_POLL_PERIOD";
     public static final String POLL_TIMEOUT = "UPDATEBOT_POLL_TIMEOUT";
 
+    public static final String MERGE = "UPDATEBOT_MERGE";
+    public static final String CHECK_PR_STATUS = "UPDATEBOT_CHECK_PR_STATUS";
+
     public static final String DRY_RUN = "UPDATEBOT_DRY_RUN";
 
     public static final String MVN_COMMAND = "UPDATEBOT_MVN_COMMAND";

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequestLoop.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequestLoop.java
@@ -31,6 +31,8 @@ import java.util.Map;
 
 import static io.jenkins.updatebot.EnvironmentVariables.POLL_PERIOD;
 import static io.jenkins.updatebot.EnvironmentVariables.POLL_TIMEOUT;
+import static io.jenkins.updatebot.EnvironmentVariables.MERGE;
+import static io.jenkins.updatebot.EnvironmentVariables.CHECK_PR_STATUS;
 import static io.jenkins.updatebot.commands.StatusInfo.isPending;
 
 /**
@@ -41,10 +43,10 @@ public class UpdatePullRequestLoop extends CommandSupport {
     private static final transient Logger LOG = LoggerFactory.getLogger(UpdatePullRequestLoop.class);
 
     @Parameter(names = "--merge", description = "Whether we should merge Pull Requests that are Open and have a successful last commit status", arity = 1)
-    private boolean mergeOnSuccess = true;
+    private boolean mergeOnSuccess = Systems.isConfigBoolean(MERGE,true);
 
     @Parameter(names = "--check-pr-status", description = "Whether we should check the status of Pull Requests before merging them", arity = 1)
-    private boolean checkPrStatus = true;
+    private boolean checkPrStatus = Systems.isConfigBoolean(CHECK_PR_STATUS,true);
 
     @Parameter(names = "--poll-time-ms", description = "The poll period", arity = 1)
     private long pollTimeMillis = Systems.getConfigLongValue(POLL_PERIOD, 2 * 60 * 1000);
@@ -123,6 +125,7 @@ public class UpdatePullRequestLoop extends CommandSupport {
     protected UpdatePullRequests createUpdatePullRequestsCommand() {
         UpdatePullRequests answer = new UpdatePullRequests();
         answer.setMergeOnSuccess(mergeOnSuccess);
+        answer.setCheckPrStatus(checkPrStatus);
         return answer;
     }
 

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequestLoop.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequestLoop.java
@@ -43,6 +43,9 @@ public class UpdatePullRequestLoop extends CommandSupport {
     @Parameter(names = "--merge", description = "Whether we should merge Pull Requests that are Open and have a successful last commit status", arity = 1)
     private boolean mergeOnSuccess = true;
 
+    @Parameter(names = "--check-pr-status", description = "Whether we should check the status of Pull Requests before merging them", arity = 1)
+    private boolean checkPrStatus = true;
+
     @Parameter(names = "--poll-time-ms", description = "The poll period", arity = 1)
     private long pollTimeMillis = Systems.getConfigLongValue(POLL_PERIOD, 2 * 60 * 1000);
 

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
@@ -25,6 +25,7 @@ import io.jenkins.updatebot.github.PullRequests;
 import io.jenkins.updatebot.support.Markdown;
 import io.jenkins.updatebot.support.Strings;
 import io.fabric8.utils.Objects;
+import io.jenkins.updatebot.support.Systems;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHCommitStatus;
 import org.kohsuke.github.GHIssue;
@@ -38,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 
+import static io.jenkins.updatebot.EnvironmentVariables.CHECK_PR_STATUS;
+import static io.jenkins.updatebot.EnvironmentVariables.MERGE;
 import static io.jenkins.updatebot.github.GitHubHelpers.getLastCommitStatus;
 import static io.jenkins.updatebot.github.Issues.getLabels;
 import static io.jenkins.updatebot.github.Issues.isOpen;
@@ -51,10 +54,10 @@ public class UpdatePullRequests extends CommandSupport {
     private static final transient Logger LOG = LoggerFactory.getLogger(UpdatePullRequests.class);
 
     @Parameter(names = "--merge", description = "Whether we should merge Pull Requests that are Open and have a successful last commit status", arity = 1)
-    private boolean mergeOnSuccess = true;
+    private boolean mergeOnSuccess = Systems.isConfigBoolean(MERGE,true);
 
     @Parameter(names = "--check-pr-status", description = "Whether we should check the status of Pull Requests before merging them", arity = 1)
-    private boolean checkPrStatus = true;
+    private boolean checkPrStatus = Systems.isConfigBoolean(CHECK_PR_STATUS,true);
 
     public boolean isMergeOnSuccess() {
         return mergeOnSuccess;

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/support/Systems.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/support/Systems.java
@@ -72,4 +72,16 @@ public class Systems {
         String value = getConfigValue(envVar);
         return value != null && value.equalsIgnoreCase("true");
     }
+
+    /**
+     * Returns value of the env var or system property if set, otherwise the specified default value
+     * Different from a flag as a flag is always false if not present
+     */
+    public static boolean isConfigBoolean(String envVar, boolean defaultValue) {
+        String value = getConfigValue(envVar);
+        if( value != null ){
+            return Boolean.parseBoolean(envVar);
+        }
+        return defaultValue;
+    }
 }


### PR DESCRIPTION
fixes https://github.com/jenkins-x/updatebot/issues/45

Also exposed the existing mergeOnSuccess option (choice of whether to merge if sucessful, in case where a check is performed) as an env var