### PR TITLE
each updatebot run to only delete the PRs that it merged

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
@@ -104,6 +104,7 @@ public class UpdatePullRequests extends CommandSupport {
     public void run(CommandContext context) throws IOException {
         Status contextStatus = Status.COMPLETE;
         GHRepository ghRepository = context.gitHubRepository();
+
         if (ghRepository != null) {
 
             // lets look for a pending issue
@@ -134,7 +135,6 @@ public class UpdatePullRequests extends CommandSupport {
                                 if (state != null && state.equals(GHCommitState.SUCCESS)) {
                                     String message = Markdown.UPDATEBOT_ICON + " merging this pull request as its CI was successful";
                                     mergePr(pullRequest, message);
-
                                 }
                             }
                         } catch (IOException e) {
@@ -157,9 +157,6 @@ public class UpdatePullRequests extends CommandSupport {
                 }
             }
         }
-        if(contextStatus == Status.COMPLETE && deleteMergedBranches){
-            GitHubHelpers.deleteUpdateBotBranches(ghRepository);
-        }
         context.setStatus(contextStatus);
     }
 
@@ -168,6 +165,10 @@ public class UpdatePullRequests extends CommandSupport {
         GHPullRequest.MergeMethod gitMergeMethod = Arrays.stream(GHPullRequest.MergeMethod.values())
                 .filter(e -> e.name().equalsIgnoreCase(mergeMethod)).findAny().orElse(GHPullRequest.MergeMethod.MERGE);
         pullRequest.merge(message,null,gitMergeMethod);
+
+        if(deleteMergedBranches){
+            GitHubHelpers.deleteUpdateBotBranch(pullRequest.getRepository(),pullRequest.getHead().getRef());
+        }
     }
 
     /**

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/github/GitHubHelpers.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/github/GitHubHelpers.java
@@ -123,14 +123,30 @@ public class GitHubHelpers {
         if (ghRepository != null) {
             Map<String, GHBranch> branches = ghRepository.getBranches();
             for (GHBranch ghBranch : branches.values()) {
-                String name = ghBranch.getName();
-                if (name.startsWith("updatebot-")) {
-                    //delete as per https://github.com/kohsuke/github-api/pull/164#issuecomment-78391771
-                    //heads needed as per https://developer.github.com/v3/git/refs/#get-a-reference
-                    ghRepository.getRef("heads/"+ghBranch.getName()).delete();
-                }
+                deleteUpdateBotBranch(ghRepository, ghBranch);
             }
         }
+    }
+
+    public static void deleteUpdateBotBranches(GHRepository ghRepository, List<String> branchNames) throws IOException{
+        for(String branchName:branchNames){
+            deleteUpdateBotBranch(ghRepository,branchName);
+        }
+    }
+
+    public static void deleteUpdateBotBranch(GHRepository ghRepository, GHBranch ghBranch) throws IOException {
+        deleteUpdateBotBranch(ghRepository,ghBranch.getName());
+
+    }
+
+    public static void deleteUpdateBotBranch(GHRepository ghRepository, String branchName) throws IOException{
+        if (branchName.startsWith("updatebot-")) {
+            //delete as per https://github.com/kohsuke/github-api/pull/164#issuecomment-78391771
+            //heads needed as per https://developer.github.com/v3/git/refs/#get-a-reference
+            ghRepository.getRef("heads/"+branchName).delete();
+            LOG.info("deleted branch "+branchName+" for "+ghRepository.getFullName());
+        }
+
     }
 
     public static GHPerson getOrganisationOrUser(GitHub github, String orgName) {


### PR DESCRIPTION
fixes https://github.com/jenkins-x/updatebot/issues/50

We've repos that both try to push updates to the same downstream, so looking at all updatebot branches means they race on them. But using this new version am able restrict each updatebot to just deleting the branches that it merged and it now logs to show this (an example of a PR merged and deleted running this is https://github.com/Activiti/ttc-rb-english-campaign/pull/19 )

The change is achieved by moving the delete logic into the `mergePr` method rather than giving it its own loop