### PR TITLE
Commit status check

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
@@ -130,9 +130,10 @@ public class UpdatePullRequests extends CommandSupport {
                     if (mergeOnSuccess && checkPrStatus) {
                         try {
                             GHCommitStatus status = getLastCommitStatus(ghRepository, pullRequest);
+                            ghRepository.getLastCommitStatus(pullRequest.getHead().getSha());
                             if (status != null) {
                                 GHCommitState state = status.getState();
-                                if (state != null && state.equals(GHCommitState.SUCCESS)) {
+                                if (state != null && state.equals(GHCommitState.SUCCESS) && GitHubHelpers.checkCommitStatus(ghRepository,pullRequest,GHCommitState.SUCCESS)) {
                                     String message = Markdown.UPDATEBOT_ICON + " merging this pull request as its CI was successful";
                                     mergePr(pullRequest, message);
                                 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/UpdatePullRequests.java
@@ -104,6 +104,7 @@ public class UpdatePullRequests extends CommandSupport {
     public void run(CommandContext context) throws IOException {
         Status contextStatus = Status.COMPLETE;
         GHRepository ghRepository = context.gitHubRepository();
+
         if (ghRepository != null) {
 
             // lets look for a pending issue
@@ -134,7 +135,6 @@ public class UpdatePullRequests extends CommandSupport {
                                 if (state != null && state.equals(GHCommitState.SUCCESS)) {
                                     String message = Markdown.UPDATEBOT_ICON + " merging this pull request as its CI was successful";
                                     mergePr(pullRequest, message);
-
                                 }
                             }
                         } catch (IOException e) {
@@ -157,9 +157,6 @@ public class UpdatePullRequests extends CommandSupport {
                 }
             }
         }
-        if(contextStatus == Status.COMPLETE && deleteMergedBranches){
-            GitHubHelpers.deleteUpdateBotBranches(ghRepository);
-        }
         context.setStatus(contextStatus);
     }
 
@@ -168,6 +165,10 @@ public class UpdatePullRequests extends CommandSupport {
         GHPullRequest.MergeMethod gitMergeMethod = Arrays.stream(GHPullRequest.MergeMethod.values())
                 .filter(e -> e.name().equalsIgnoreCase(mergeMethod)).findAny().orElse(GHPullRequest.MergeMethod.MERGE);
         pullRequest.merge(message,null,gitMergeMethod);
+
+        if(deleteMergedBranches){
+            GitHubHelpers.deleteUpdateBotBranch(pullRequest.getRepository(),pullRequest.getHead().getRef());
+        }
     }
 
     /**

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/github/GitHubHelpers.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/github/GitHubHelpers.java
@@ -123,14 +123,30 @@ public class GitHubHelpers {
         if (ghRepository != null) {
             Map<String, GHBranch> branches = ghRepository.getBranches();
             for (GHBranch ghBranch : branches.values()) {
-                String name = ghBranch.getName();
-                if (name.startsWith("updatebot-")) {
-                    //delete as per https://github.com/kohsuke/github-api/pull/164#issuecomment-78391771
-                    //heads needed as per https://developer.github.com/v3/git/refs/#get-a-reference
-                    ghRepository.getRef("heads/"+ghBranch.getName()).delete();
-                }
+                deleteUpdateBotBranch(ghRepository, ghBranch);
             }
         }
+    }
+
+    public static void deleteUpdateBotBranches(GHRepository ghRepository, List<String> branchNames) throws IOException{
+        for(String branchName:branchNames){
+            deleteUpdateBotBranch(ghRepository,branchName);
+        }
+    }
+
+    public static void deleteUpdateBotBranch(GHRepository ghRepository, GHBranch ghBranch) throws IOException {
+        deleteUpdateBotBranch(ghRepository,ghBranch.getName());
+
+    }
+
+    public static void deleteUpdateBotBranch(GHRepository ghRepository, String branchName) throws IOException{
+        if (branchName.startsWith("updatebot-")) {
+            //delete as per https://github.com/kohsuke/github-api/pull/164#issuecomment-78391771
+            //heads needed as per https://developer.github.com/v3/git/refs/#get-a-reference
+            ghRepository.getRef("heads/"+branchName).delete();
+            LOG.info("deleted branch "+branchName+" for "+ghRepository.getFullName());
+        }
+
     }
 
     public static GHPerson getOrganisationOrUser(GitHub github, String orgName) {


### PR DESCRIPTION
Have been seeing that sometimes PRs get merged even when there are pending status checks and I've told the updatebot to wait for checks. For example https://api.github.com/repos/Activiti/Activiti/statuses/d0992e954d1a7aa8c781584cb0d308354d25019b corresponds to https://github.com/Activiti/activiti/pull/2029 and in the details you can see that one of the checks was pending when it was merged. Another one merged by our jx user (so updatebot within the platform) is https://github.com/Activiti/Activiti/pull/2012 . It has pending statuses but notice that the top status was success - https://api.github.com/repos/activiti/Activiti/statuses/092ffa028fadcc5c3a56fc2c5a062678cbae5ac8 , whereas the second status is pending

It could be that the library that the [updatebot is using](https://github.com/jenkins-x/updatebot/blob/master/updatebot-core/src/main/java/io/jenkins/updatebot/github/GitHubHelpers.java#L152) is just taking the most recently-reported status and using that - https://github.com/kohsuke/github-api/blob/master/src/main/java/org/kohsuke/github/GHRepository.java#L1078

But a commit actually gets a list of statuses if there are multiple checks. So it could be that updatebot is merging once it sees that the most recent check was a green check, even if there are still checks pending. If that is the cause then a solution might be to check the other statuses