### PR TITLE
feat: use single pull request for downstream repositories

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
@@ -23,6 +23,7 @@ import io.jenkins.updatebot.support.Strings;
 public class GitRepositoryConfig extends DtoSupport {
     private String name;
     private String branch; // need to resolve branch name at runtime
+    private boolean useSinglePullRequest; // use single pull request to push commits from upstream
     private Dependencies push;
     private Dependencies pull;
 
@@ -38,10 +39,11 @@ public class GitRepositoryConfig extends DtoSupport {
         String nameText = Strings.notEmpty(name) ? "name='" + name + '\'' : "";
         String pushText = push != null ? "push=" + push : "";
         String pullText = pull != null ? "pull=" + pull : "";
-        String branchText = pull != null ? "branch=" + branch : "";
+        String branchText = branch != null ? "branch=" + branch : "";
+        String singlePullRequestText = "useSinglePullRequest=" + useSinglePullRequest;
 
         return "GitRepositoryConfig{" +
-                Strings.joinNotEmpty(", ", nameText, pushText, pullText, branchText) + '}';
+                Strings.joinNotEmpty(", ", nameText, pushText, pullText, branchText, singlePullRequestText) + '}';
     }
 
     public String getName() {
@@ -74,6 +76,14 @@ public class GitRepositoryConfig extends DtoSupport {
 
     public void setBranch(String branch) {
         this.branch = branch;
+    }
+
+    public boolean isUseSinglePullRequest() {
+        return this.useSinglePullRequest;
+    }
+
+    public void setUseSinglePullRequest(boolean single) {
+        this.useSinglePullRequest = single;
     }
 
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/repository/LocalRepository.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/repository/LocalRepository.java
@@ -226,4 +226,16 @@ public class LocalRepository {
         }
         return config.getBranch();
     }
+
+    /**
+     * Returns true if the repository is configured to use single pull request to add a new version push commit
+     */
+    public boolean isUseSinglePullRequest() {
+        GitRepositoryConfig config = repo.getRepositoryDetails();
+        if (config == null) {
+            return false;
+        }
+
+        return config.isUseSinglePullRequest();
+    }
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/support/MarkupHelper.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/support/MarkupHelper.java
@@ -18,18 +18,21 @@ package io.jenkins.updatebot.support;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import io.fabric8.utils.Files;
 import io.fabric8.utils.IOHelpers;
 
-import javax.tools.FileObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.net.URL;
+
+import javax.tools.FileObject;
 
 /**
  */
@@ -40,6 +43,7 @@ public class MarkupHelper {
     public static ObjectMapper createYamlObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true); // support mapping into case sensitive Java class attribute names
         return objectMapper;
     }
 

--- a/updatebot-core/src/test/java/io/jenkins/updatebot/RepositoryConfigTest.java
+++ b/updatebot-core/src/test/java/io/jenkins/updatebot/RepositoryConfigTest.java
@@ -72,4 +72,25 @@ public class RepositoryConfigTest {
         assertThat(repositoryConfig.getGithub().findOrganisation("jstrachan-testing").findRepository("updatebot").getBranch()).isNull();
     }
 
+    @Test
+    public void testUseSinglePullRequestConfigurations() throws Exception {
+        // given
+        String configFile = new File(Tests.getBasedir(), "src/test/resources/maven/source/updatebot.yml").getPath();
+        testSubject.setConfigFile(configFile);
+
+        // when
+        RepositoryConfig repositoryConfig = pushSourceChanges.getRepositoryConfig(testSubject);
+
+        // then
+        assertThat(repositoryConfig.getGithub().findOrganisation("jstrachan-testing")
+                   .findRepository("fabric8")
+                   .isUseSinglePullRequest()
+                  ).isFalse();
+
+        assertThat(repositoryConfig.getGithub().findOrganisation("jstrachan-testing")
+                   .findRepository("fabric8-maven-plugin")
+                   .isUseSinglePullRequest()
+                  ).isTrue();
+
+    }
 }

--- a/updatebot-core/src/test/resources/maven/source/updatebot.yml
+++ b/updatebot-core/src/test/resources/maven/source/updatebot.yml
@@ -5,3 +5,5 @@ github:
     - name: kubernetes-client
     - name: fabric8
     - name: fabric8-maven-plugin
+      useSinglePullRequest: true
+


### PR DESCRIPTION
Currently, any updatebot push-version command will create a separate PR in the downstream repository for each upstream source. This makes it impossible to use with distributed Maven projects that need to propagate their versions through a build graph into a single PR in aggregator pom repository to validate that all common dependency versions for managed pom modules converge before merging valid managed dependencies artifacts into release branch.

This PR introduces optional attribute `useSinglePullRequest` for Github repositories in .updatebot.yml configuration file to add, commit and push version changes into single pull request to downstream repository from multiple upstream repositories, so that, if `useSinglePullRequest` is set to `true` for repository in .updatebot.yml, the updatebot push-version command will

1. Resolve and checkout an existing pull request branch from downstream repository
2. Add version changes commits with comments into local pull request branch
3. Push changes into single pull request remote branch to trigger PR preview job.

I had setup the following repositories in my Jenkins-X cluster to test Updatebot binary built from this PR:

https://github.com/igdianov/foo

```yaml
github:
  organisations:
  - name: igdianov
    repositories:
    - name: bar
    - name: foobar
      useSinglePullRequest: true
``` 

https://github.com/igdianov/bar

```yaml
github:
  organisations:
  - name: igdianov
    repositories:
    - name: foobar
      useSinglePullRequest: true
``` 

https://github.com/igdianov/foobar

```yaml
github:
  organisations:
  - name: igdianov
    repositories:
``` 

The repositories are configured so that any successful commit to Foo master pushes its release version to Bar with normal PR and Foobar with single PR. Any successful commit to Bar master pushes Bar version to Foobar with single PR. Foobar pom.xml is using Maven enforcer plugin to validate dependency convergence between managed modules for each commit pushed into single PR branch.  The PR build fails fast if the current dependencies do not converge.

Once all versions change commits have been propagated and validated for single Foobar PR, the foobar-tests module will run integration tests and let Jenkins report the pr status back to Github. Then the single PR with valid status will be merged into master to build and deploy foobar-dependencies artifact with valid managed dependencies versions bundle downstream.
 