### PR TITLE
fix: lets default to use a prow `/approve` command on PRs

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/Configuration.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/Configuration.java
@@ -93,6 +93,8 @@ public class Configuration {
     private String npmCommand = Systems.getConfigValue(EnvironmentVariables.NPM_COMMAND, "npm");
     @Parameter(names = {"--jenkinsfile-git-repo"}, description = "The git URL to clone for the Jenkinsfile library")
     private String jenksinsfileGitRepo = Systems.getConfigValue(EnvironmentVariables.JENKINSFILE_GIT_REPO, DEFAULT_JENKINSFILE_LIBRARY_GIT_URL);
+    @Parameter(names = {"--pr-command"}, description = "The Prow Pull Request command to append to Pull Request body content")
+    private String prowPRCommand = Systems.getConfigValue(EnvironmentVariables.PROW_PR_COMMAND, "/approve");
 
     private File sourceDir;
     private boolean rebaseMode = true;
@@ -327,6 +329,14 @@ public class Configuration {
 
     public void setNpmEnvironmentVariables(Map<String, String> npmEnvironmentVariables) {
         this.npmEnvironmentVariables = npmEnvironmentVariables;
+    }
+
+    public String getProwPRCommand() {
+        return prowPRCommand;
+    }
+
+    public void setProwPRCommand(String prowPRCommand) {
+        this.prowPRCommand = prowPRCommand;
     }
 
     public String getJenksinsfileGitRepo() {

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/EnvironmentVariables.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/EnvironmentVariables.java
@@ -39,5 +39,7 @@ public class EnvironmentVariables {
     public static final String MVN_COMMAND = "UPDATEBOT_MVN_COMMAND";
     public static final String NPM_COMMAND = "UPDATEBOT_NPM_COMMAND";
 
+    public static final String PROW_PR_COMMAND = "UPDATEBOT_PROW_PR_COMMAND";
+
     public static final String JENKINSFILE_GIT_REPO = "UPDATEBOT_JENKINSFILE_GIT_REPO";
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/CommandContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/CommandContext.java
@@ -15,6 +15,7 @@
  */
 package io.jenkins.updatebot.commands;
 
+import io.fabric8.utils.Strings;
 import io.jenkins.updatebot.Configuration;
 import io.jenkins.updatebot.git.GitPlugin;
 import io.jenkins.updatebot.github.GitHubHelpers;
@@ -187,7 +188,7 @@ public class CommandContext {
         if (child != null) {
             return child.createPullRequestBody();
         }
-        return Markdown.GENERATED_BY;
+        return Markdown.GENERATED_BY +  createPullRequestBodyCommands();
     }
 
     protected void addChild(CommandContext child) {
@@ -230,6 +231,18 @@ public class CommandContext {
 
     public void error(Logger log, String message, Throwable e) {
         getConfiguration().error(log, message, e);
+    }
+
+
+    /**
+     * Creates a Prow command as part of a pull request
+     */
+    protected String createPullRequestBodyCommands() {
+        String prowCommand = getConfiguration().getProwPRCommand();
+        if (Strings.isNotBlank(prowCommand)) {
+            return "\n\n" + prowCommand;
+        }
+        return "";
     }
 
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushRegexChangesContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushRegexChangesContext.java
@@ -46,8 +46,9 @@ public class PushRegexChangesContext extends CommandContext {
 
     @Override
     public String createPullRequestBody() {
-        return Markdown.UPDATEBOT_ICON + " pushed regex: `" + command.getRegex() + "` to: `" + command.getValue() + "`";
+        return Markdown.UPDATEBOT_ICON + " pushed regex: `" + command.getRegex() + "` to: `" + command.getValue() + "`" + createPullRequestBodyCommands();
     }
+
 
     @Override
     public String createCommit() {

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushSourceChangesContext.java
@@ -49,7 +49,7 @@ public class PushSourceChangesContext extends CommandContext {
 
         return Markdown.UPDATEBOT_ICON + " pushed version changes from the source code in repository: " +
                 linkText +
-                " ref: `" + ref + "`\n";
+                " ref: `" + ref + "`\n" + createPullRequestBodyCommands();
     }
 
     @Override

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushVersionChangesContext.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/PushVersionChangesContext.java
@@ -52,7 +52,7 @@ public class PushVersionChangesContext extends CommandContext {
 
     @Override
     public String createPullRequestBody() {
-        return Markdown.UPDATEBOT_ICON + " pushed " + step.getKind() + " dependency: `" + step.getDependency() + "` to: `" + step.getVersion() + "`";
+        return Markdown.UPDATEBOT_ICON + " pushed " + step.getKind() + " dependency: `" + step.getDependency() + "` to: `" + step.getVersion() + "`" + createPullRequestBodyCommands();
     }
 
     @Override


### PR DESCRIPTION
but lets let folks configure the prow command used, if any, via an environment variable