### PR TITLE
enable dry run without git credentials

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
@@ -62,7 +62,7 @@ public abstract class ModifyFilesCommandSupport extends CommandSupport {
 
     public void run(CommandContext context, GHRepository ghRepository, GHPullRequest pullRequest) throws IOException {
         prepareDirectory(context);
-        if (doProcess(context)) {
+        if (doProcess(context) && !context.getConfiguration().isDryRun()) {
             processPullRequest(context, ghRepository, pullRequest);
         }
     }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
@@ -67,7 +67,7 @@ public class GitPluginCLI implements GitPlugin {
         String personName = null;
         try {
             GitHub github = configuration.getGithub();
-            if (github != null && !github.isAnonymous()) {
+            if (github != null && !configuration.isDryRun()) {
                 GHMyself myself = github.getMyself();
                 if (myself != null) {
                     email = myself.getEmail();

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
@@ -67,7 +67,7 @@ public class GitPluginCLI implements GitPlugin {
         String personName = null;
         try {
             GitHub github = configuration.getGithub();
-            if (github != null) {
+            if (github != null && !github.isAnonymous()) {
                 GHMyself myself = github.getMyself();
                 if (myself != null) {
                     email = myself.getEmail();


### PR DESCRIPTION
This is useful for running in dry-run mode as it means you can test out applying changes without entering github credentials and just do anonymous clone. Otherwise if you run in dry-run mode without creds and without this change then you get the below error because the getMyself operation requires authentication.

```
Exception in thread "main" java.lang.IllegalStateException: This operation requires a credential but none is given to the GitHub constructor
	at org.kohsuke.github.GitHub.requireCredential(GitHub.java:293)
	at org.kohsuke.github.GitHub.getMyself(GitHub.java:379)
	at io.jenkins.updatebot.git.GitPluginCLI.configUserNameAndEmail(GitPluginCLI.java:71)
```

I found that I also needed to skip the code for updating an existing pull request in the case of a dry run, otherwise without creds it seems to get stuck there. Skipping this in dry run still allows me to see what changes are calculated, which is what I'm then interested in.

Was able to run [real updates to PRs](https://github.com/ryandawsonuk/jhipster-sample-app/pull/4) with these changes in place too

Came across this when preparing a [demo on using the bot](https://dzone.com/articles/using-jenkins-x-updatebot), which is [what I've been using to test](https://github.com/ryandawsonuk/usingupdatebot)