### PR TITLE
Stop mixing prs across branches

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
@@ -357,10 +357,10 @@ public abstract class ModifyFilesCommandSupport extends CommandSupport {
                     for(GitRepositoryConfig repo :org.getRepositories()){
                         if(pullRequest.getRepository().getName().equalsIgnoreCase(repo.getName())){
 
+
                             if (title != null && title.startsWith(prefix)) {
-                                //TODO: find base branch of PR
-                                //pullRequest.getBase() presumably isn't it as that's a commit pointer
-                                if(repo.getBranch() ==null || repo.getBranch().equalsIgnoreCase("FIXME!")) {
+
+                                if(repo.getBranch() ==null || repo.getBranch().equalsIgnoreCase(pullRequest.getBase().getRef())) {
                                     return pullRequest;
                                 }
                             }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
@@ -377,7 +377,7 @@ public abstract class ModifyFilesCommandSupport extends CommandSupport {
     protected String createSinglePullRequestTitle(CommandContext context) {
         String baseBranch = resolveBaseBranch(context); 
 
-        return createSinglePullRequestPrefix(context) + " to base ref " + baseBranch; 
+        return createSinglePullRequestPrefix(context) + " into " + baseBranch; 
     }
     
     /**

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/commands/ModifyFilesCommandSupport.java
@@ -62,7 +62,7 @@ public abstract class ModifyFilesCommandSupport extends CommandSupport {
 
     public void run(CommandContext context, GHRepository ghRepository, GHPullRequest pullRequest) throws IOException {
         prepareDirectory(context);
-        if (doProcess(context)) {
+        if (doProcess(context) && !context.getConfiguration().isDryRun()) {
             processPullRequest(context, ghRepository, pullRequest);
         }
     }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
@@ -67,7 +67,7 @@ public class GitPluginCLI implements GitPlugin {
         String personName = null;
         try {
             GitHub github = configuration.getGithub();
-            if (github != null && !github.isAnonymous()) {
+            if (github != null && !configuration.isDryRun()) {
                 GHMyself myself = github.getMyself();
                 if (myself != null) {
                     email = myself.getEmail();

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/git/GitPluginCLI.java
@@ -67,7 +67,7 @@ public class GitPluginCLI implements GitPlugin {
         String personName = null;
         try {
             GitHub github = configuration.getGithub();
-            if (github != null) {
+            if (github != null && !github.isAnonymous()) {
                 GHMyself myself = github.getMyself();
                 if (myself != null) {
                     email = myself.getEmail();


### PR DESCRIPTION
Currently having trouble with pipelines so can't merge right now. http://jenkins.jx.35.240.9.95.nip.io/job/Activiti/job/activiti-build/job/7.0.x/12/console resulted in https://github.com/Activiti/Activiti/pull/2556/files , which is a mixture of the 7.0.x and 7.1.x release trains - more specifically the 7.0.x train made a commit to overwrite a PR on the 7.1.x train

That PR is https://api.github.com/repos/Activiti/Activiti/pulls/2556 - from there we can see that the base branch has a ref (`develop`) and updatebot needs to check the base branch ref [against its yaml file for that repo](https://github.com/Activiti/activiti-build/blob/develop/.updatebot.yml) before performing the update

Also happens to include changes for https://github.com/jenkins-x/updatebot/pull/69 as based on same fork