### PR TITLE
feat: allow excludeUpdateLoop to be defined for github repositories

### DIFF
--- a/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/model/GitRepositoryConfig.java
@@ -24,6 +24,7 @@ public class GitRepositoryConfig extends DtoSupport {
     private String name;
     private String branch; // need to resolve branch name at runtime
     private boolean useSinglePullRequest; // use single pull request to push commits from upstream
+    private Boolean excludeUpdateLoop;
     private Dependencies push;
     private Dependencies pull;
 
@@ -84,6 +85,14 @@ public class GitRepositoryConfig extends DtoSupport {
 
     public void setUseSinglePullRequest(boolean single) {
         this.useSinglePullRequest = single;
+    }
+
+    public Boolean getExcludeUpdateLoop() {
+        return excludeUpdateLoop;
+    }
+
+    public void setExcludeUpdateLoop(Boolean excludeUpdateLoop) {
+        this.excludeUpdateLoop = excludeUpdateLoop;
     }
 
 }

--- a/updatebot-core/src/main/java/io/jenkins/updatebot/model/GithubRepository.java
+++ b/updatebot-core/src/main/java/io/jenkins/updatebot/model/GithubRepository.java
@@ -39,6 +39,9 @@ public class GithubRepository extends GitRepository {
     public GithubRepository(GHRepository ghRepository, GitRepositoryConfig details) {
         this(ghRepository);
         setRepositoryDetails(details);
+        if (details.getExcludeUpdateLoop() != null) {
+            setExcludeUpdateLoop(details.getExcludeUpdateLoop());
+        }
     }
 
     @Override


### PR DESCRIPTION
this setting was only available for git repositories, so let's enable it for github repositories too

so that we can write something like the following, to get auto-merge of PRs in some repos, but not all
(here we want to enable auto-deploy to staging but not prod)

```
github:
  organisations:
  - name: xxxx
    repositories:
    # auto-deploy to staging env
    - name: staging-env
    # manual deploy to prod env
    - name: prod-env
      excludeUpdateLoop: true
```